### PR TITLE
Non static initialization

### DIFF
--- a/src/java/src/main/java/fr/acinq/Secp256k1Loader.java
+++ b/src/java/src/main/java/fr/acinq/Secp256k1Loader.java
@@ -32,11 +32,11 @@ import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 
 /**
- * Set the system properties, org.sqlite.lib.path, org.sqlite.lib.name,
- * appropriately so that the SQLite JDBC driver can find *.dll, *.jnilib and
+ * Set the system properties, fr.acinq.secp256k1.lib.path, fr.acinq.secp256k1.lib.name,
+ * appropriately so that the JVM can find *.dll, *.jnilib and
  * *.so files, according to the current OS (win, linux, mac).
  * The library files are automatically extracted from this project's package (JAR).
- * usage: call {@link #initialize()} before using SQLite JDBC driver.
+ * usage: call {@link #initialize()} before using NativeSecp256k1.
  *
  * @author leo
  */

--- a/src/java/src/main/java/org/bitcoin/NativeSecp256k1.java
+++ b/src/java/src/main/java/org/bitcoin/NativeSecp256k1.java
@@ -39,12 +39,27 @@ import static org.bitcoin.NativeSecp256k1Util.*;
  */
 public class NativeSecp256k1 {
 
-    private static final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
-    private static final Lock r = rwl.readLock();
-    private static final Lock w = rwl.writeLock();
-    private static ThreadLocal<ByteBuffer> nativeECDSABuffer = new ThreadLocal<ByteBuffer>();
+    private final ReentrantReadWriteLock rwl;
+    private final Lock r;
+    private final Lock w;
+    private ThreadLocal<ByteBuffer> nativeECDSABuffer;
+    private final Secp256k1Context context;
 
-    private static ByteBuffer pack(byte[]... buffers) {
+    public NativeSecp256k1() {
+        context = new Secp256k1Context();
+        NativeSecp256k1Util.checkArgument(context.isEnabled());
+
+        rwl = new ReentrantReadWriteLock();
+        r = rwl.readLock();
+        w = rwl.writeLock();
+        nativeECDSABuffer = new ThreadLocal<ByteBuffer>();
+    }
+
+    public boolean isEnabled() {
+        return context.isEnabled();
+    }
+
+    private ByteBuffer pack(byte[]... buffers) {
         int size = 0;
         for(int i = 0; i < buffers.length; i++) {
             size += buffers[i].length;
@@ -72,13 +87,13 @@ public class NativeSecp256k1 {
      * @return true if the signature is valid
      * @throws AssertFailException in case of failure
      */
-    public static boolean verify(byte[] data, byte[] signature, byte[] pub) throws AssertFailException {
+    public boolean verify(byte[] data, byte[] signature, byte[] pub) throws AssertFailException {
         checkArgument(data.length == 32 && signature.length <= 520 && pub.length <= 520);
         ByteBuffer byteBuff = pack(data, signature, pub);
 
         r.lock();
         try {
-            return secp256k1_ecdsa_verify(byteBuff, Secp256k1Context.getContext(), signature.length, pub.length) == 1;
+            return secp256k1_ecdsa_verify(byteBuff, context.getContext(), signature.length, pub.length) == 1;
         } finally {
             r.unlock();
         }
@@ -92,7 +107,7 @@ public class NativeSecp256k1 {
      * @return a signature, or an empty array is signing failed
      * @throws AssertFailException in case of failure
      */
-    public static byte[] sign(byte[] data, byte[] sec) throws AssertFailException {
+    public byte[] sign(byte[] data, byte[] sec) throws AssertFailException {
         checkArgument(data.length == 32 && sec.length <= 32);
         ByteBuffer byteBuff = pack(data, sec);
 
@@ -100,7 +115,7 @@ public class NativeSecp256k1 {
 
         r.lock();
         try {
-            retByteArray = secp256k1_ecdsa_sign(byteBuff, Secp256k1Context.getContext());
+            retByteArray = secp256k1_ecdsa_sign(byteBuff, context.getContext());
         } finally {
             r.unlock();
         }
@@ -124,14 +139,14 @@ public class NativeSecp256k1 {
      * @return a signature, or an empty array is signing failed
      * @throws AssertFailException in case of failure
      */
-    public static byte[] signCompact(byte[] data, byte[] sec) throws AssertFailException {
+    public byte[] signCompact(byte[] data, byte[] sec) throws AssertFailException {
         checkArgument(data.length == 32 && sec.length <= 32);
         ByteBuffer byteBuff = pack(data, sec);
         byte[][] retByteArray;
 
         r.lock();
         try {
-            retByteArray = secp256k1_ecdsa_sign_compact(byteBuff, Secp256k1Context.getContext());
+            retByteArray = secp256k1_ecdsa_sign_compact(byteBuff, context.getContext());
         } finally {
             r.unlock();
         }
@@ -151,13 +166,13 @@ public class NativeSecp256k1 {
      * @param seckey ECDSA Secret key, 32 bytes
      * @return true if seckey is valid
      */
-    public static boolean secKeyVerify(byte[] seckey) {
+    public boolean secKeyVerify(byte[] seckey) {
         checkArgument(seckey.length == 32);
         ByteBuffer byteBuff = pack(seckey);
 
         r.lock();
         try {
-            return secp256k1_ec_seckey_verify(byteBuff, Secp256k1Context.getContext()) == 1;
+            return secp256k1_ec_seckey_verify(byteBuff, context.getContext()) == 1;
         } finally {
             r.unlock();
         }
@@ -172,7 +187,7 @@ public class NativeSecp256k1 {
      * @return the corresponding public key (uncompressed)
      */
     //TODO add a 'compressed' arg
-    public static byte[] computePubkey(byte[] seckey) throws AssertFailException {
+    public byte[] computePubkey(byte[] seckey) throws AssertFailException {
         checkArgument(seckey.length == 32);
         ByteBuffer byteBuff = pack(seckey);
 
@@ -180,7 +195,7 @@ public class NativeSecp256k1 {
 
         r.lock();
         try {
-            retByteArray = secp256k1_ec_pubkey_create(byteBuff, Secp256k1Context.getContext());
+            retByteArray = secp256k1_ec_pubkey_create(byteBuff, context.getContext());
         } finally {
             r.unlock();
         }
@@ -199,7 +214,7 @@ public class NativeSecp256k1 {
      * @return the input public key (uncompressed) if valid, or an empty array
      * @throws AssertFailException in case of failure
      */
-    public static byte[] parsePubkey(byte[] pubkey) throws AssertFailException {
+    public byte[] parsePubkey(byte[] pubkey) throws AssertFailException {
         checkArgument(pubkey.length == 33 || pubkey.length == 65);
         ByteBuffer byteBuff = pack(pubkey);
 
@@ -207,7 +222,7 @@ public class NativeSecp256k1 {
 
         r.lock();
         try {
-            retByteArray = secp256k1_ec_pubkey_parse(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+            retByteArray = secp256k1_ec_pubkey_parse(byteBuff, context.getContext(), pubkey.length);
         } finally {
             r.unlock();
         }
@@ -225,32 +240,32 @@ public class NativeSecp256k1 {
      * libsecp256k1 Cleanup - This destroys the secp256k1 context object
      * This should be called at the end of the program for proper cleanup of the context.
      */
-    public static synchronized void cleanup() {
+    public synchronized void cleanup() {
         w.lock();
         try {
-            secp256k1_destroy_context(Secp256k1Context.getContext());
+            secp256k1_destroy_context(context.getContext());
         } finally {
             w.unlock();
         }
     }
 
-    public static long cloneContext() {
+    public long cloneContext() {
         r.lock();
         try {
-            return secp256k1_ctx_clone(Secp256k1Context.getContext());
+            return secp256k1_ctx_clone(context.getContext());
         } finally {
             r.unlock();
         }
     }
 
-    public static byte[] privKeyNegate(byte[] privkey) throws AssertFailException {
+    public byte[] privKeyNegate(byte[] privkey) throws AssertFailException {
         checkArgument(privkey.length == 32);
         ByteBuffer byteBuff = pack(privkey);
 
         byte[][] retByteArray;
         r.lock();
         try {
-            retByteArray = secp256k1_privkey_negate(byteBuff, Secp256k1Context.getContext());
+            retByteArray = secp256k1_privkey_negate(byteBuff, context.getContext());
         } finally {
             r.unlock();
         }
@@ -273,14 +288,14 @@ public class NativeSecp256k1 {
      * @return privkey * tweak
      * @throws AssertFailException in case of failure
      */
-    public static byte[] privKeyTweakMul(byte[] privkey, byte[] tweak) throws AssertFailException {
+    public byte[] privKeyTweakMul(byte[] privkey, byte[] tweak) throws AssertFailException {
         checkArgument(privkey.length == 32);
         ByteBuffer byteBuff = pack(privkey, tweak);
 
         byte[][] retByteArray;
         r.lock();
         try {
-            retByteArray = secp256k1_privkey_tweak_mul(byteBuff, Secp256k1Context.getContext());
+            retByteArray = secp256k1_privkey_tweak_mul(byteBuff, context.getContext());
         } finally {
             r.unlock();
         }
@@ -304,14 +319,14 @@ public class NativeSecp256k1 {
      * @return privkey + tweak
      * @throws AssertFailException in case of failure
      */
-    public static byte[] privKeyTweakAdd(byte[] privkey, byte[] tweak) throws AssertFailException {
+    public byte[] privKeyTweakAdd(byte[] privkey, byte[] tweak) throws AssertFailException {
         checkArgument(privkey.length == 32);
         ByteBuffer byteBuff = pack(privkey, tweak);
 
         byte[][] retByteArray;
         r.lock();
         try {
-            retByteArray = secp256k1_privkey_tweak_add(byteBuff, Secp256k1Context.getContext());
+            retByteArray = secp256k1_privkey_tweak_add(byteBuff, context.getContext());
         } finally {
             r.unlock();
         }
@@ -328,14 +343,14 @@ public class NativeSecp256k1 {
         return privArr;
     }
 
-    public static byte[] pubKeyNegate(byte[] pubkey) throws AssertFailException {
+    public byte[] pubKeyNegate(byte[] pubkey) throws AssertFailException {
         checkArgument(pubkey.length == 33 || pubkey.length == 65);
         ByteBuffer byteBuff = pack(pubkey);
 
         byte[][] retByteArray;
         r.lock();
         try {
-            retByteArray = secp256k1_pubkey_negate(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+            retByteArray = secp256k1_pubkey_negate(byteBuff, context.getContext(), pubkey.length);
         } finally {
             r.unlock();
         }
@@ -359,14 +374,14 @@ public class NativeSecp256k1 {
      * @return pubkey + tweak
      * @throws AssertFailException in case of failure
      */
-    public static byte[] pubKeyTweakAdd(byte[] pubkey, byte[] tweak) throws AssertFailException {
+    public byte[] pubKeyTweakAdd(byte[] pubkey, byte[] tweak) throws AssertFailException {
         checkArgument(pubkey.length == 33 || pubkey.length == 65);
         ByteBuffer byteBuff = pack(pubkey, tweak);
 
         byte[][] retByteArray;
         r.lock();
         try {
-            retByteArray = secp256k1_pubkey_tweak_add(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+            retByteArray = secp256k1_pubkey_tweak_add(byteBuff, context.getContext(), pubkey.length);
         } finally {
             r.unlock();
         }
@@ -391,14 +406,14 @@ public class NativeSecp256k1 {
      * @return pubkey * tweak
      * @throws AssertFailException in case of failure
      */
-    public static byte[] pubKeyTweakMul(byte[] pubkey, byte[] tweak) throws AssertFailException {
+    public byte[] pubKeyTweakMul(byte[] pubkey, byte[] tweak) throws AssertFailException {
         checkArgument(pubkey.length == 33 || pubkey.length == 65);
         ByteBuffer byteBuff = pack(pubkey, tweak);
 
         byte[][] retByteArray;
         r.lock();
         try {
-            retByteArray = secp256k1_pubkey_tweak_mul(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+            retByteArray = secp256k1_pubkey_tweak_mul(byteBuff, context.getContext(), pubkey.length);
         } finally {
             r.unlock();
         }
@@ -415,7 +430,7 @@ public class NativeSecp256k1 {
         return pubArr;
     }
 
-    public static byte[] pubKeyAdd(byte[] pubkey1, byte[] pubkey2) throws AssertFailException {
+    public byte[] pubKeyAdd(byte[] pubkey1, byte[] pubkey2) throws AssertFailException {
         checkArgument(pubkey1.length == 33 || pubkey1.length == 65);
         checkArgument(pubkey2.length == 33 || pubkey2.length == 65);
         ByteBuffer byteBuff = pack(pubkey1, pubkey2);
@@ -423,7 +438,7 @@ public class NativeSecp256k1 {
         byte[][] retByteArray;
         r.lock();
         try {
-            retByteArray = secp256k1_ec_pubkey_add(byteBuff, Secp256k1Context.getContext(), pubkey1.length, pubkey2.length);
+            retByteArray = secp256k1_ec_pubkey_add(byteBuff, context.getContext(), pubkey1.length, pubkey2.length);
         } finally {
             r.unlock();
         }
@@ -447,14 +462,14 @@ public class NativeSecp256k1 {
      * @return ecdh(sedckey, pubkey)
      * @throws AssertFailException in case of failure
      */
-    public static byte[] createECDHSecret(byte[] seckey, byte[] pubkey) throws AssertFailException {
+    public byte[] createECDHSecret(byte[] seckey, byte[] pubkey) throws AssertFailException {
         checkArgument(seckey.length <= 32 && pubkey.length <= 65);
         ByteBuffer byteBuff = pack(seckey, pubkey);
 
         byte[][] retByteArray;
         r.lock();
         try {
-            retByteArray = secp256k1_ecdh(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+            retByteArray = secp256k1_ecdh(byteBuff, context.getContext(), pubkey.length);
         } finally {
             r.unlock();
         }
@@ -475,13 +490,13 @@ public class NativeSecp256k1 {
      * @return true if successful
      * @throws AssertFailException in case of failure
      */
-    public static synchronized boolean randomize(byte[] seed) throws AssertFailException {
+    public synchronized boolean randomize(byte[] seed) throws AssertFailException {
         checkArgument(seed.length == 32 || seed == null);
         ByteBuffer byteBuff = pack(seed);
 
         w.lock();
         try {
-            return secp256k1_context_randomize(byteBuff, Secp256k1Context.getContext()) == 1;
+            return secp256k1_context_randomize(byteBuff, context.getContext()) == 1;
         } finally {
             w.unlock();
         }

--- a/src/java/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/src/java/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -21,38 +21,31 @@ package org.bitcoin;
  * to handle ECDSA operations.
  */
 public class Secp256k1Context {
-  private static final boolean enabled; //true if the library is loaded
-  private static final long context; //ref to pointer to context obj
+  private final boolean enabled; //true if the library is loaded
+  private final long context; //ref to pointer to context obj
 
-  static { //static initializer
-      boolean isEnabled = true;
-      long contextRef = -1;
-      try {
-          if ("The Android Project".equals(System.getProperty("java.vm.vendor"))) {
-              System.loadLibrary("secp256k1");
-          } else {
-              fr.acinq.Secp256k1Loader.initialize();
-          }
-          contextRef = secp256k1_init_context();
-      } catch (java.lang.UnsatisfiedLinkError e) {
-          System.out.println("Cannot load secp256k1 native library: " + e.toString());
-          isEnabled = false;
-      } catch (Exception e) {
-          System.out.println("Cannot load secp256k1 native library: " + e.toString());
-          isEnabled = false;
-      }
-      enabled = isEnabled;
-      context = contextRef;
+  public Secp256k1Context() {
+    boolean isEnabled = true;
+    long contextRef = -1;
+    try {
+      System.loadLibrary("secp256k1");
+      contextRef = secp256k1_init_context();
+    } catch (UnsatisfiedLinkError e) {
+      System.out.println("UnsatisfiedLinkError: " + e.toString());
+      isEnabled = false;
+    }
+    enabled = isEnabled;
+    context = contextRef;
   }
 
-  public static boolean isEnabled() {
-     return enabled;
+  public boolean isEnabled() {
+    return enabled;
   }
 
-  public static long getContext() {
-     if(!enabled) return -1; //sanity check
-     return context;
+  public long getContext() {
+    if(!enabled) return -1; //sanity check
+    return context;
   }
 
-  private static native long secp256k1_init_context();
+  private native long secp256k1_init_context();
 }

--- a/src/java/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/src/java/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -28,10 +28,17 @@ public class Secp256k1Context {
     boolean isEnabled = true;
     long contextRef = -1;
     try {
-      System.loadLibrary("secp256k1");
+      if ("The Android Project".equals(System.getProperty("java.vm.vendor"))) {
+        System.loadLibrary("secp256k1");
+      } else {
+        fr.acinq.Secp256k1Loader.initialize();
+      }
       contextRef = secp256k1_init_context();
-    } catch (UnsatisfiedLinkError e) {
-      System.out.println("UnsatisfiedLinkError: " + e.toString());
+    } catch (java.lang.UnsatisfiedLinkError e) {
+      System.out.println("Cannot load secp256k1 native library: " + e.toString());
+      isEnabled = false;
+    } catch (Exception e) {
+      System.out.println("Cannot load secp256k1 native library: " + e.toString());
       isEnabled = false;
     }
     enabled = isEnabled;
@@ -47,5 +54,5 @@ public class Secp256k1Context {
     return context;
   }
 
-  private native long secp256k1_init_context();
+  private static native long secp256k1_init_context();
 }

--- a/src/java/src/test/java/org/bitcoin/NativeSecp256k1Test.java
+++ b/src/java/src/test/java/org/bitcoin/NativeSecp256k1Test.java
@@ -14,6 +14,7 @@ import static org.bitcoin.NativeSecp256k1Util.*;
 public class NativeSecp256k1Test {
 
     //TODO improve comments/add more tests
+    NativeSecp256k1 nativeSecp = new NativeSecp256k1();
 
     /**
      * This tests verify() for a valid signature
@@ -25,11 +26,11 @@ public class NativeSecp256k1Test {
         byte[] sig = BaseEncoding.base16().lowerCase().decode("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589".toLowerCase());
         byte[] pub = BaseEncoding.base16().lowerCase().decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40".toLowerCase());
 
-        result = NativeSecp256k1.verify(data, sig, pub);
+        result = nativeSecp.verify(data, sig, pub);
         assertEquals(result, true, "testVerifyPos");
 
         byte[] sigCompact = BaseEncoding.base16().lowerCase().decode("79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589".toLowerCase());
-        result = NativeSecp256k1.verify(data, sigCompact, pub);
+        result = nativeSecp.verify(data, sigCompact, pub);
         assertEquals(result, true, "testVerifyPos");
     }
 
@@ -43,7 +44,7 @@ public class NativeSecp256k1Test {
         byte[] sig = BaseEncoding.base16().lowerCase().decode("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589".toLowerCase());
         byte[] pub = BaseEncoding.base16().lowerCase().decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40".toLowerCase());
 
-        result = NativeSecp256k1.verify(data, sig, pub);
+        result = nativeSecp.verify(data, sig, pub);
         //System.out.println(" TEST " + new BigInteger(1, resultbytes).toString(16));
         assertEquals(result, false, "testVerifyNeg");
     }
@@ -56,7 +57,7 @@ public class NativeSecp256k1Test {
         boolean result = false;
         byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
 
-        result = NativeSecp256k1.secKeyVerify(sec);
+        result = nativeSecp.secKeyVerify(sec);
         //System.out.println(" TEST " + new BigInteger(1, resultbytes).toString(16));
         assertEquals(result, true, "testSecKeyVerifyPos");
     }
@@ -69,7 +70,7 @@ public class NativeSecp256k1Test {
         boolean result = false;
         byte[] sec = BaseEncoding.base16().lowerCase().decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".toLowerCase());
 
-        result = NativeSecp256k1.secKeyVerify(sec);
+        result = nativeSecp.secKeyVerify(sec);
         //System.out.println(" TEST " + new BigInteger(1, resultbytes).toString(16));
         assertEquals(result, false, "testSecKeyVerifyNeg");
     }
@@ -81,7 +82,7 @@ public class NativeSecp256k1Test {
     public void testPubKeyCreatePos() throws AssertFailException {
         byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
 
-        byte[] resultArr = NativeSecp256k1.computePubkey(sec);
+        byte[] resultArr = nativeSecp.computePubkey(sec);
         String pubkeyString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(pubkeyString, "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6", "testPubKeyCreatePos");
     }
@@ -93,7 +94,7 @@ public class NativeSecp256k1Test {
     public void testPubKeyCreateNeg() throws AssertFailException {
         byte[] sec = BaseEncoding.base16().lowerCase().decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".toLowerCase());
 
-        byte[] resultArr = NativeSecp256k1.computePubkey(sec);
+        byte[] resultArr = nativeSecp.computePubkey(sec);
         String pubkeyString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(pubkeyString, "", "testPubKeyCreateNeg");
     }
@@ -101,11 +102,11 @@ public class NativeSecp256k1Test {
     @Test
     public void testPubKeyNegatePos() throws AssertFailException {
         byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
-        byte[] pubkey = NativeSecp256k1.computePubkey(sec);
+        byte[] pubkey = nativeSecp.computePubkey(sec);
         String pubkeyString = BaseEncoding.base16().upperCase().encode(pubkey);
         assertEquals(pubkeyString, "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6", "testPubKeyCreatePos");
 
-        byte[] pubkey1 = NativeSecp256k1.pubKeyNegate(pubkey);
+        byte[] pubkey1 = nativeSecp.pubKeyNegate(pubkey);
         String pubkeyString1 = BaseEncoding.base16().upperCase().encode(pubkey1);
         assertEquals(pubkeyString1, "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2DDEFC12B6B8E73968536514302E69ED1DDB24B999EFEE79C12D03AB17E79E1989", "testPubKeyNegatePos");
     }
@@ -116,7 +117,7 @@ public class NativeSecp256k1Test {
     @Test
     public void testPubKeyParse() throws AssertFailException {
         byte[] pub = BaseEncoding.base16().lowerCase().decode("02C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D".toLowerCase());
-        byte[] resultArr = NativeSecp256k1.parsePubkey(pub);
+        byte[] resultArr = nativeSecp.parsePubkey(pub);
         String pubkeyString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(pubkeyString, "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6", "testPubKeyAdd");
     }
@@ -125,7 +126,7 @@ public class NativeSecp256k1Test {
     public void testPubKeyAdd() throws AssertFailException {
         byte[] pub1 = BaseEncoding.base16().lowerCase().decode("041b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f70beaf8f588b541507fed6a642c5ab42dfdf8120a7f639de5122d47a69a8e8d1".toLowerCase());
         byte[] pub2 = BaseEncoding.base16().lowerCase().decode("044d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d07662a3eada2d0fe208b6d257ceb0f064284662e857f57b66b54c198bd310ded36d0".toLowerCase());
-        byte[] pub3 = NativeSecp256k1.pubKeyAdd(pub1, pub2);
+        byte[] pub3 = nativeSecp.pubKeyAdd(pub1, pub2);
         String pubkeyString = BaseEncoding.base16().upperCase().encode(pub3);
         assertEquals(pubkeyString, "04531FE6068134503D2723133227C867AC8FA6C83C537E9A44C3C5BDBDCB1FE3379E92C265E71E481BA82A84675A47AC705A200FCD524E92D93B0E7386F26A5458", "testPubKeyAdd");
     }
@@ -139,7 +140,7 @@ public class NativeSecp256k1Test {
         byte[] data = BaseEncoding.base16().lowerCase().decode("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90".toLowerCase()); //sha256hash of "testing"
         byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
 
-        byte[] resultArr = NativeSecp256k1.sign(data, sec);
+        byte[] resultArr = nativeSecp.sign(data, sec);
         String sigString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(sigString, "30440220182A108E1448DC8F1FB467D06A0F3BB8EA0533584CB954EF8DA112F1D60E39A202201C66F36DA211C087F3AF88B50EDF4F9BDAA6CF5FD6817E74DCA34DB12390C6E9", "testSignPos");
     }
@@ -152,7 +153,7 @@ public class NativeSecp256k1Test {
         byte[] data = BaseEncoding.base16().lowerCase().decode("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90".toLowerCase()); //sha256hash of "testing"
         byte[] sec = BaseEncoding.base16().lowerCase().decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".toLowerCase());
 
-        byte[] resultArr = NativeSecp256k1.sign(data, sec);
+        byte[] resultArr = nativeSecp.sign(data, sec);
         String sigString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(sigString, "", "testSignNeg");
     }
@@ -163,7 +164,7 @@ public class NativeSecp256k1Test {
         byte[] data = BaseEncoding.base16().lowerCase().decode("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90".toLowerCase()); //sha256hash of "testing"
         byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
 
-        byte[] resultArr = NativeSecp256k1.signCompact(data, sec);
+        byte[] resultArr = nativeSecp.signCompact(data, sec);
         String sigString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(sigString, "182A108E1448DC8F1FB467D06A0F3BB8EA0533584CB954EF8DA112F1D60E39A21C66F36DA211C087F3AF88B50EDF4F9BDAA6CF5FD6817E74DCA34DB12390C6E9", "testSignCompactPos");
         //assertEquals( sigString, "30 44 02 20 182A108E1448DC8F1FB467D06A0F3BB8EA0533584CB954EF8DA112F1D60E39A2 02 20 1C66F36DA211C087F3AF88B50EDF4F9BDAA6CF5FD6817E74DCA34DB12390C6E9" , "testSignPos");
@@ -172,9 +173,9 @@ public class NativeSecp256k1Test {
     @Test
     public void testPrivKeyTweakNegate() throws AssertFailException {
         byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
-        byte[] sec1 = NativeSecp256k1.privKeyNegate(sec);
+        byte[] sec1 = nativeSecp.privKeyNegate(sec);
         assertEquals(BaseEncoding.base16().upperCase().encode(sec1), "981A9A7DD677A622518DA068D66D5F824E5F22F084B8A0E2F195B5662F300C11", "testPrivKeyNegate");
-        byte[] sec2 = NativeSecp256k1.privKeyNegate(sec1);
+        byte[] sec2 = nativeSecp.privKeyNegate(sec1);
         assert (Arrays.equals(sec, sec2));
     }
 
@@ -186,7 +187,7 @@ public class NativeSecp256k1Test {
         byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
         byte[] data = BaseEncoding.base16().lowerCase().decode("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3".toLowerCase()); //sha256hash of "tweak"
 
-        byte[] resultArr = NativeSecp256k1.privKeyTweakAdd(sec, data);
+        byte[] resultArr = nativeSecp.privKeyTweakAdd(sec, data);
         String sigString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(sigString, "A168571E189E6F9A7E2D657A4B53AE99B909F7E712D1C23CED28093CD57C88F3", "testPrivKeyAdd_1");
     }
@@ -199,7 +200,7 @@ public class NativeSecp256k1Test {
         byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
         byte[] data = BaseEncoding.base16().lowerCase().decode("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3".toLowerCase()); //sha256hash of "tweak"
 
-        byte[] resultArr = NativeSecp256k1.privKeyTweakMul(sec, data);
+        byte[] resultArr = nativeSecp.privKeyTweakMul(sec, data);
         String sigString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(sigString, "97F8184235F101550F3C71C927507651BD3F1CDB4A5A33B8986ACF0DEE20FFFC", "testPrivKeyMul_1");
     }
@@ -212,7 +213,7 @@ public class NativeSecp256k1Test {
         byte[] pub = BaseEncoding.base16().lowerCase().decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40".toLowerCase());
         byte[] data = BaseEncoding.base16().lowerCase().decode("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3".toLowerCase()); //sha256hash of "tweak"
 
-        byte[] resultArr = NativeSecp256k1.pubKeyTweakAdd(pub, data);
+        byte[] resultArr = nativeSecp.pubKeyTweakAdd(pub, data);
         String sigString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(sigString, "0411C6790F4B663CCE607BAAE08C43557EDC1A4D11D88DFCB3D841D0C6A941AF525A268E2A863C148555C48FB5FBA368E88718A46E205FABC3DBA2CCFFAB0796EF", "testPrivKeyAdd_2");
     }
@@ -225,7 +226,7 @@ public class NativeSecp256k1Test {
         byte[] pub = BaseEncoding.base16().lowerCase().decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40".toLowerCase());
         byte[] data = BaseEncoding.base16().lowerCase().decode("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3".toLowerCase()); //sha256hash of "tweak"
 
-        byte[] resultArr = NativeSecp256k1.pubKeyTweakMul(pub, data);
+        byte[] resultArr = nativeSecp.pubKeyTweakMul(pub, data);
         String sigString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(sigString, "04E0FE6FE55EBCA626B98A807F6CAF654139E14E5E3698F01A9A658E21DC1D2791EC060D4F412A794D5370F672BC94B722640B5F76914151CFCA6E712CA48CC589", "testPrivKeyMul_2");
     }
@@ -236,7 +237,7 @@ public class NativeSecp256k1Test {
     @Test
     public void testRandomize() throws AssertFailException {
         byte[] seed = BaseEncoding.base16().lowerCase().decode("A441B15FE9A3CF56661190A0B93B9DEC7D04127288CC87250967CF3B52894D11".toLowerCase()); //sha256hash of "random"
-        boolean result = NativeSecp256k1.randomize(seed);
+        boolean result = nativeSecp.randomize(seed);
         assertEquals(result, true, "testRandomize");
     }
 
@@ -246,7 +247,7 @@ public class NativeSecp256k1Test {
         byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
         byte[] pub = BaseEncoding.base16().lowerCase().decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40".toLowerCase());
 
-        byte[] resultArr = NativeSecp256k1.createECDHSecret(sec, pub);
+        byte[] resultArr = nativeSecp.createECDHSecret(sec, pub);
         String ecdhString = BaseEncoding.base16().upperCase().encode(resultArr);
         assertEquals(ecdhString, "2A2A67007A926E6594AF3EB564FC74005B37A9C8AEF2033C4552051B5C87F043", "testCreateECDHSecret");
     }


### PR DESCRIPTION
To be compatible with graal AOT compilation the JNI bindings must not have static initializers, this PR aims at implementing the required changes.